### PR TITLE
Fix markdown (Admonition) Error. Easier to read and copy the url

### DIFF
--- a/docs/charts/stable/authentik/how_to.md
+++ b/docs/charts/stable/authentik/how_to.md
@@ -82,11 +82,12 @@ Once `authentik` is setup and running, you must create a `forwardAuth` inside `T
 
 ![Traefik-forwardAuth](img/Traefik-forwardAuth.png)
 
-- The main thing about this screen is to use the internal DNS name for simplicity
-
+:::note
+The main thing about this screen is to use the internal DNS name for simplicity
 :::
+```
 http://authentik-http.ix-authentik.svc.cluster.local:10230/outpost.goauthentik.io/auth/traefik
-:::
+```
 
 There's also a list of `authResponseHeaders` inside `authentik` listed for use with `Traefik`, so in case you need them here they are.
 


### PR DESCRIPTION
Signed-off-by: inmanturbo <47095624+inmanturbo@users.noreply.github.com>



**⚙️ Type of change**
Fix small typo in docs (markdown parse error)
**🧪 How Has This Been Tested?**
Docusaurus playground

