### PR TITLE
Typo in networking option guide

### DIFF
--- a/docs/manual/SCALE/options/networking.md
+++ b/docs/manual/SCALE/options/networking.md
@@ -43,7 +43,7 @@ If shown, one may choose the `Service Type` for their application. Might be mult
   - This port exposes the container port on the service. This port is the `external` port to reach the application.
   - To change the `interal` / Target Port or `Port Type` one must click on the `Show Advanced Settings` box.
 
-:::Warning Show Export Config
+:::warning Show Export Config
 
 Checking the `Show Export Config` box enables one to change many expert or advanced options not described here. Enabling them may render you application unable to deploy and is advised for advanced Kubernetes users only.
 


### PR DESCRIPTION
**Description**
Not working warning block:
![image](https://user-images.githubusercontent.com/20801821/228605259-c70ed619-f020-40f2-9fcd-5212920d079b.png)

Correctly working warning block:
![image](https://user-images.githubusercontent.com/20801821/228605046-e1925760-a1b8-4d0f-92c5-d13a81b175a3.png)

Only difference I can see between the two is capitalization. So I assume that's why it's not rendering correctly. I haven't tested this, so it's only a guess.