### PR TITLE
docs(lldap): fix upstream link

### DIFF
--- a/docs/charts/stable/lldap/installation-notes.md
+++ b/docs/charts/stable/lldap/installation-notes.md
@@ -22,7 +22,7 @@ When setting your bind user you should avoid using the admin user as this is a s
 
 ## Support
 
-- If you need more details or have a more custom setup the documentation on the [upstream](https://github.com/ldap/ldap) is very useful so check the descriptions of the options there including example configs for various apps.
+- If you need more details or have a more custom setup the documentation on the [upstream](https://github.com/lldap/lldap) is very useful so check the descriptions of the options there including example configs for various apps.
 - You can also reach us using [Discord](https://discord.gg/tVsPTHWTtr) for real-time feedback and support
 
 ---


### PR DESCRIPTION
**Description**
While setting up LLDAP and reading the documentation I noticed that the upstream link is broken. This fixes the link.

⚒️ Fixes  # (not filed)

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [x] 📖 Documentation

**🧪 How Has This Been Tested?**
I haven't tested this directly. However, the updated URL points to the correct location for the upstream LLDAP project.

**📃 Notes:**
N/A

**✔️ Checklist:**

- [x] ⚖️ My code follows the style guidelines of this project
- [x] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [x] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
