### PR TITLE
Updated postgres export script for CNPG

### DIFF
--- a/docs/manual/SCALE/guides/sql-export.md
+++ b/docs/manual/SCALE/guides/sql-export.md
@@ -49,7 +49,7 @@ folder="./dumps/"
 mkdir -p "$folder"
 
 # get namespaces with postgres database pod
-namespaces=$(k3s kubectl get pods -A | grep postgres | awk '{print $1}')
+namespaces=$(k3s kubectl get pods -A | grep cnpg | awk '{print $1}') | sort -nu
 
 for ns in $namespaces; do
   # extract application name

--- a/docs/manual/SCALE/guides/sql-export.md
+++ b/docs/manual/SCALE/guides/sql-export.md
@@ -49,7 +49,7 @@ folder="./dumps/"
 mkdir -p "$folder"
 
 # get namespaces with postgres database pod
-namespaces=$(k3s kubectl get pods -A | grep cnpg | awk '{print $1}') | sort -nu
+namespaces=$(k3s kubectl get pods -A | grep cnpg | awk '{print $1}' | sort -nu)
 
 for ns in $namespaces; do
   # extract application name


### PR DESCRIPTION
With the migration to Cloud Native Postgres (CNPG) the pod names have changed. This PR updates the grep portion of the command to return the newly named pods.