### PR TITLE
docs(pvc-migration-guide): remove heavyscript

### DIFF
--- a/docs/manual/SCALE/guides/migration-pvc.md
+++ b/docs/manual/SCALE/guides/migration-pvc.md
@@ -40,7 +40,6 @@ For apps installed with a different name, it will be `<app-name>-<default-name>`
 So for `vaultwarden` (the default name), it will be `vaultwarden`. But for the vaultwarden app that was installed with the name `testwarden`, it will be `testwarden-vaultwarden`.
 
 :::caution Replace the names in the angle brackets before executing commands
-Alternatively, you can use [HeavyScript]([url](https://github.com/Heavybullets8/heavy_script)) (ver 2.0.0+) to stop the new CNPG-enabled app.
 ```bash
 k3s kubectl scale deploy <app-name>-<default-name> -n ix-<app-name> --replicas=0
 k3s kubectl scale deploy <app-name> -n ix-<app-name> --replicas=0
@@ -49,7 +48,6 @@ k3s kubectl scale deploy <app-name> -n ix-<app-name> --replicas=0
 :::
 
 :::caution Example commands for apps with name vaultwarden and testwarden
-Alternatively, you can use [HeavyScript]([url](https://github.com/Heavybullets8/heavy_script)) (ver 2.0.0+) to stop the new CNPG-enabled app.
 ```bash
 k3s kubectl scale deploy testwarden-vaultwarden -n ix-testwarden --replicas=0
 k3s kubectl scale deploy vaultwarden -n ix-vaultwarden --replicas=0


### PR DESCRIPTION
**Description**
Remove heavyscript as option to scale down app as it uses stop-all and the database will be stopped.

⚒️ Fixes  #

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**

**📃 Notes:**

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
