### PR TITLE
Adding guide for recovering hanging CNPG Apps after TrueNAS Scale reboot

### DIFF
--- a/docs/manual/SCALE/guides/recover-cnpg.md
+++ b/docs/manual/SCALE/guides/recover-cnpg.md
@@ -2,6 +2,13 @@
 
 Apps with a PostgreSQL database that were updated to the new CNPG common sometimes don't survive a reboot of TrueNAS Scale. The App then hangs on _DEPLOYING_ and pods are in state _Completed_ or _TaintToleration_.
 
+:::caution Best Effort Policy
+
+This guide has been written with the best efforts of the staff and tested as best possible. We are not responsible if it doesn't work for every scenario or user situation or if you suffer data loss as a result. 
+This guide has been tested with TrueNAS SCALE 22.12.4.2, Cobia beta, CNPG 1.20.2_2.0.3 and HomeAssistant 2023.10.3_20.0.12.
+
+:::
+
 ## Symptoms
 If you have rebooted and your Apps are hanging on _DEPLOYING_, check if you see pods in state _Completed_ or _TaintToleration_ and the apps main pod in state _Init_ with the 
 command `k3s kubectl get all -n ix-<app-name> `.

--- a/docs/manual/SCALE/guides/recover-cnpg.md
+++ b/docs/manual/SCALE/guides/recover-cnpg.md
@@ -1,0 +1,91 @@
+# Recover CNPG App after Reboot
+
+Apps with a PostgreSQL database that were updated to the new CNPG common sometimes don't survive a reboot of TrueNAS Scale. The App then hangs on _DEPLOYING_ and pods are in state _Completed_ or _TaintToleration_.
+
+## Symptoms
+If you have rebooted and your Apps are hanging on _DEPLOYING_, check if you see pods in state _Completed_ or _TaintToleration_ and the apps main pod in state _Init_ with the 
+command `k3s kubectl get all -n ix-<app-name> `.
+
+```bash
+Examples:
+
+k3s kubectl get all -n ix-home-assistant
+NAME                                  READY   STATUS            RESTARTS   AGE
+pod/home-assistant-cnpg-main-1        0/1     TaintToleration   0          12h
+pod/home-assistant-cnpg-main-2        0/1     TaintToleration   0          12h
+pod/home-assistant-85865456d5-tc8h4   0/1     TaintToleration   0          12h
+pod/home-assistant-85865456d5-kl96x   0/1     Init:0/2          0          12h
+
+k3s kubectl get all -n ix-home-assistant
+NAME                                               READY   STATUS      RESTARTS   AGE
+pod/home-assistant-cnpg-main-2                    0/1     Completed   0          22m
+pod/home-assistant-cnpg-main-rw-df9bcbccc-s8z2n   0/1     Completed   0          23m
+pod/home-assistant-cnpg-main-rw-df9bcbccc-ptltn   0/1     Completed   0          23m
+pod/home-assistant-cnpg-main-rw-df9bcbccc-jbbcj   1/1     Running     0          12m
+pod/home-assistant-5867d984d9-gfznd               0/1     Completed   0          23m
+pod/home-assistant-cnpg-main-1                    0/1     Completed   0          23m
+pod/home-assistant-cnpg-main-rw-df9bcbccc-q2w2d   1/1     Running     0          12m
+pod/home-assistant-5867d984d9-vcp6x               0/1     Init:0/2    0          12m
+```
+
+Logs from the cnpg-wait container in the main app pod show something like this:
+```bash
+Testing database on url:  home-assistant-cnpg-main-rw
+home-assistant-cnpg-main-rw:5432 - no response
+```
+
+## Recovery Steps
+To recover your app, you need to first stop it ([do not click the _Stop_ button!](https://truecharts.org/manual/FAQ#how-do-i-stop-a-truecharts-app-truenas-scale-only)), delete the hanging pods and then restart the app. 
+
+1. Stopp the app either by checking "Stop All" in the app settings or with HeavyScript.  
+```bash
+heavyscript app --stop <app-name>`
+```
+2. Wait 2-3min
+3. Delete any still hanging pods with
+```bash
+k3s kubectl delete pods -n ix-<app-name> <pod name>`  
+e.g. k3s kubectl delete pods -n ix-home-assistant home-assistant-85865456d5-tc8h4
+```
+4. Start the app either by unchecking "Stop All" in the app settings or with HeavyScript  
+```bash
+heavyscript app --start <app-name>
+```
+5. If you unchecked "Stop All" you might have to click the Start Button on the GUI (Start is safe, Stop is NOT).  
+   There also might be a task that gets stuck in TrueNAS under Jobs (top right). You can get rid of those by restarting TrueNAS GUI with
+```bash
+systemctl restart middlewared
+```
+6. Wait 2-3min
+7. Check that the app and all of its pods are running. In the third paragraph there should be no _deployment.apps_ with 0 _AVAILABLE_  
+```bash
+Example:  
+k3s kubectl get all -n ix-home-assistant`    
+NAME                                          READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/home-assistant-cnpg-main-rw   0/0     0            0           14h
+deployment.apps/home-assistant                1/1     1            1           14h
+```
+8. You can scale them up manually to 1 replica or if it's a cnpg-main-rw pod you might want 2 replicas
+```bash
+k3s kubectl scale deploy <deployment.apps-name> -n ix-<app-name> --replicas=1
+e.g. k3s kubectl scale deploy home-assistant-cnpg-main-rw -n ix-home-assistant --replicas=2
+```
+
+## Safe Reboot
+You have recovered your apps but need to reboot again? There is a safe and faster way by unsetting the app pool before rebooting:
+1. Apps --> Settings --> Unset Pool
+2. Wait for apps to scale down. No installed apps will be shown, but they are not deleted.
+3. Reboot
+4. Apps --> Settings --> Choose Pool --> select your app pool
+5. Wait for apps to scale up
+
+:::note
+
+There is already an [issue](https://github.com/truecharts/charts/issues/12420) for this problem and the CNPG code is currently being reworked that should address this.
+Please do not create additional issues or +1 comments, the devs are aware of this.
+
+:::
+
+**Credit**
+
+Thanks to [Zasx](https://github.com/ZasX) from the [TrueCharts](https://www.truecharts.org) team for the steps used to create this guide.


### PR DESCRIPTION
**Description**

HomeAssistant using the new CNPG Operator hangs sometimes after a reboot of TrueNAS Scale despite running on an SSD pool and with changed inotify settings. This has been reproduced by @ZasX on a VM. With his help, I got my App running again (see https://discord.com/channels/830763548678291466/1163422136925421639) and I want to help other users with the same issue by adding an additional Guide on the TrueCharts website.

There is an open Issue https://github.com/truecharts/charts/issues/12420 and ongoing PR https://github.com/truecharts/library-charts/pull/509 that should adress this problem, after which this guide can be removed or repurposed.

⚒️ Fixes  # <!--(issue)-->

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [x] Additional Guide for Documentation

**🧪 How Has This Been Tested?**
I checked the formatting in the Intellij Markdown renderer, but I have no possibility to check the rendering on a website.

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🪞 I have opened a PR on [truecharts/containers](https://github.com/truecharts/containers) adding the container to TrueCharts mirror repo.
- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
