### PR TITLE
Fix: typo in FAQ auto-update section

### DIFF
--- a/docs/manual/FAQ.md
+++ b/docs/manual/FAQ.md
@@ -104,7 +104,7 @@ Take backups beforehand with [HeavyScript](https://github.com/Heavybullets8/heav
 
 ## Does HeavyScript auto-update major changes?
 
-It depends on the flags you used. We recommend **NOT** using the `-U` flag, as this will update to major version changes.
+It depends on the flags you used. We recommend **NOT** using the `-a` flag, as this will update to major version changes.
 
 ## Do you offer support for breaking changes?
 


### PR DESCRIPTION
`-U` is self-update, `-a` updates to major versions
![Screenshot 2023-12-17 at 21 27 05](https://github.com/truecharts/website/assets/33390210/f71f7416-dceb-4fa4-b3f2-6a8337e2b6c1)

**Description**

⚒️ Fixes  a typo on the website

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code
- [x] 🖊️ fix typo on website
