### PR TITLE
Fix spacing and add Traefik integration for Helm Ingress guide

### DIFF
--- a/docs/manual/helm/guides/add-ingress.md
+++ b/docs/manual/helm/guides/add-ingress.md
@@ -21,22 +21,13 @@ ingress:
   main:
     enabled: true
     hosts:
-      - host: chart-example.local #Edit Required
-        paths:
-          - path: /
-            pathType: Prefix
-            overrideService:
-              name: main
-              port: 80 #Edit Required
+      - host: chart-example.local
     tls:
       - hosts:
-          - chart-example.local #Edit Required
-    integrations:
-      traefik:
-        enabled: true
+         - chart-example.local
 ```
 
-This can be expanded by adding "integrations" with cert-manager, traefik, and/or homepage, for example:
+This can be expanded by adding "integrations" with cert-manager, and/or homepage, for example:
 
 ```
 ingress:
@@ -44,12 +35,6 @@ ingress:
     enabled: true
     hosts:
       - host: chart-example.local
-        paths:
-          - path: /
-            pathType: Prefix
-            overrideService:
-              name: main
-              port: 80
     tls:
       - hosts:
           - chart-example.local
@@ -72,19 +57,6 @@ ingress:
           customkv:
             - key: some key
               value: some value
-      traefik:
-        enabled: true
-        entrypoints:
-          - websecure
-        enableFixedMiddlewares: true
-        forceTLS: true
-        allowCors: false
-        fixedMiddlewares:
-          - name: chain-basic
-            namespace: ""
-        middlewares:
-          - name: my-middleware
-            namespace: ""
 ```
 
 In somecases an ingress might already been partly defined.

--- a/docs/manual/helm/guides/add-ingress.md
+++ b/docs/manual/helm/guides/add-ingress.md
@@ -43,16 +43,16 @@ ingress:
   main:
     enabled: true
     hosts:
-      -  host: chart-example.local
-          paths:
-            - path: /
-              pathType: Prefix
-              overrideService:
-                name: main
-                port: 80
+      - host: chart-example.local
+        paths:
+          - path: /
+            pathType: Prefix
+            overrideService:
+              name: main
+              port: 80
     tls:
       - hosts:
-         - chart-example.local
+          - chart-example.local
         secretName: chart-example-tls
     integrations:
       certManager:

--- a/docs/manual/helm/guides/add-ingress.md
+++ b/docs/manual/helm/guides/add-ingress.md
@@ -14,27 +14,29 @@ Our adviced ingress controller would be Traefik.
 
 ## How-To setup
 
-To setup ingress add the following section to the values.yaml manually and adapt where needed:
+To setup ingress add the following minimal section to the values.yaml manually, update the required rows, and adapt where needed:
 
 ```
 ingress:
   main:
     enabled: true
     hosts:
-      -  host: chart-example.local
-          paths:
-            - path: /
-              pathType: Prefix
-              overrideService:
-                name: main
-                port: 80
+      - host: chart-example.local #Edit Required
+        paths:
+          - path: /
+            pathType: Prefix
+            overrideService:
+              name: main
+              port: 80 #Edit Required
     tls:
       - hosts:
-         - chart-example.local
-        secretName: chart-example-tls
+          - chart-example.local #Edit Required
+    integrations:
+      traefik:
+        enabled: true
 ```
 
-This can be expanded by adding "integrations" with cert-manager and/or homepage, for example:
+This can be expanded by adding "integrations" with cert-manager, traefik, and/or homepage, for example:
 
 ```
 ingress:
@@ -70,6 +72,19 @@ ingress:
           customkv:
             - key: some key
               value: some value
+      traefik:
+        enabled: true
+        entrypoints:
+          - websecure
+        enableFixedMiddlewares: true
+        forceTLS: true
+        allowCors: false
+        fixedMiddlewares:
+          - name: chain-basic
+            namespace: ""
+        middlewares:
+          - name: my-middleware
+            namespace: ""
 ```
 
 In somecases an ingress might already been partly defined.


### PR DESCRIPTION
**Description**
I've been learning K8s and Helm recently. The yaml spacing on the example ingress needs fixing and I also had to figure out to enable the Traefik integration.

I considered adding certmanager's integration to the base example, but left it as minimal as possible like the previous example was. 

⚒️ Fixes  # N/A

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [X] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
I did quite a few helm upgrades to test and see if this really was the minimal workable ingress setup, and it seems like it is. This works in my testing, but does use the Traefik default cert, which isn't really the TrueCharts recommended setup.

**📃 Notes:**
Thanks for the guide in the first place! It makes it much easier to jump in and get started and is a good jumping off point for reading the common docs when I need to learn more about some settings.

**✔️ Checklist:**

- [X] ⚖️ My code follows the style guidelines of this project
- [X] 👀 I have performed a self-review of my own code
- [X] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [X] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
