### PR TITLE
chore: remove ovmf and add seabios to proxmox vm guide

### DIFF
--- a/src/content/docs/clustertool/virtual-machines/proxmox.md
+++ b/src/content/docs/clustertool/virtual-machines/proxmox.md
@@ -32,46 +32,42 @@ title: Virtual Machine on Proxmox
 
 5. Check the box for `Qemu Agent`
 
-6. Select `BIOS` and choose `OVMF (UEFI)`
+6. Select `SCSI Controller` by choosing `VirtIO SCSI single`
 
-7. Select `EFI Storage` and choose a storage repository (e.g. `local-zfs`)
-
-8. Select `SCSI Controller` by choosing `VirtIO SCSI single`
-
-9. If you have a dedicated graphics card select it from the list in `Graphic card`
+7. If you have a dedicated graphics card select it from the list in `Graphic card`
 
 ![system](./img/vm-system.png)
 
-10. Select `Next` to configure disks
+8. Select `Next` to configure disks
 
-11. Select a storage repository (e.g. `local-zfs`)
+9. Select a storage repository (e.g. `local-zfs`)
 
-12. Set the disk size to `500` or `1000`
+10. Set the disk size to `500` or `1000`
 
-13. If using an SSD, then for the cache select `Write back` and check the box for `Discard`
+11. If using an SSD, then for the cache select `Write back` and check the box for `Discard`
 
 ![disks](./img/vm-disks.png)
 
-14. Select `Next` to configure CPUs
+12. Select `Next` to configure CPUs
 
-15. Select the sockets (e.g. `1`) and amount of cores to be one less than the total available processor threads (e.g. if you have a 6 core processor with HyperThreading then there are 12 available threads and the value should be `11`.)
+13. Select the sockets (e.g. `1`) and amount of cores to be one less than the total available processor threads (e.g. if you have a 6 core processor with HyperThreading then there are 12 available threads and the value should be `11`.)
 
 ![cpu](./img/vm-cpu.png)
 
-16. Select `Next` to configure memory
+14. Select `Next` to configure memory
 
-17. The minimum memory value should be `8192` and the recommended value is `16384` or more Megabytes
+15. The minimum memory value should be `8192` and the recommended value is `16384` or more Megabytes
 
 ![memory](./img/vm-memory.png)
 
-18. Select `Next` to configure network
+16. Select `Next` to configure network
 
-19. Select a bridge such as the default `vmbr0`. Optionally add a VLAN tag
+17. Select a bridge such as the default `vmbr0`. Optionally add a VLAN tag
 
 ![network](./img/vm-network.png)
 
-20. Select `Next` to confirm
+18. Select `Next` to confirm
 
-21. Review settings and optionally select the box for `Start after created` then select `Finish`.
+19. Review settings and optionally select the box for `Start after created` then select `Finish`.
 
 ![confirm](./img/vm-confirm.png)


### PR DESCRIPTION
**Description**
OVMF (UEFI) in Proxmox requires additional configuration on the users which is confusing. SeaBIOS is the path of least resistance to getting Talos running in a VM and thus the changes reflect that configuration to ease the support requests.

⚒️ Fixes  # Updated guide.

**⚙️ Type of change**

- [ ] ⚙️ Feature/App addition
- [ ] 🪛 Bugfix
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🔃 Refactor of current code

**🧪 How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

**📃 Notes:**
<!-- Please enter any other relevant information here -->

**✔️ Checklist:**

- [ ] ⚖️ My code follows the style guidelines of this project
- [ ] 👀 I have performed a self-review of my own code
- [ ] #️⃣ I have commented my code, particularly in hard-to-understand areas
- [ ] 📄 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] 🧪 I have added tests to this description that prove my fix is effective or that my feature works
- [ ] ⬆️ I increased versions for any altered app according to semantic versioning
- [ ] I made sure the title starts with `feat(chart-name):`, `fix(chart-name):` or `chore(chart-name):`

**➕ App addition**

If this PR is an app addition please make sure you have done the following.

- [ ] 🖼️ I have added an icon in the Chart's root directory called `icon.png`

---

_Please don't blindly check all the boxes. Read them and only check those that apply.
Those checkboxes are there for the reviewer to see what is this all about and
the status of this PR with a quick glance._
